### PR TITLE
Allow passing a data type to the rust plugin function

### DIFF
--- a/minimal_plugin/Cargo.lock
+++ b/minimal_plugin/Cargo.lock
@@ -92,6 +92,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -166,6 +169,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-targets",
 ]
 
@@ -300,6 +304,9 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "enum_dispatch"
@@ -542,9 +549,11 @@ name = "minimal-plugin"
 version = "0.1.0"
 dependencies = [
  "polars",
+ "polars-plan",
  "pyo3",
  "pyo3-polars",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -768,6 +777,7 @@ dependencies = [
  "polars-schema",
  "polars-utils",
  "ryu",
+ "serde",
  "simdutf8",
  "streaming-iterator",
  "strength_reduce",
@@ -828,6 +838,7 @@ dependencies = [
  "rand_distr",
  "rayon",
  "regex",
+ "serde",
  "thiserror",
  "version_check",
  "xxhash-rust",
@@ -898,12 +909,14 @@ dependencies = [
  "polars-arrow",
  "polars-core",
  "polars-error",
+ "polars-parquet",
  "polars-schema",
  "polars-time",
  "polars-utils",
  "rayon",
  "regex",
  "ryu",
+ "serde",
  "simdutf8",
 ]
 
@@ -976,6 +989,7 @@ dependencies = [
  "polars-utils",
  "rayon",
  "regex",
+ "serde",
  "unicode-reverse",
  "version_check",
 ]
@@ -997,6 +1011,7 @@ dependencies = [
  "polars-compute",
  "polars-error",
  "polars-utils",
+ "serde",
  "simdutf8",
  "streaming-decompression",
 ]
@@ -1052,6 +1067,7 @@ dependencies = [
  "rayon",
  "recursive",
  "regex",
+ "serde",
  "strum_macros",
  "version_check",
 ]
@@ -1077,6 +1093,7 @@ dependencies = [
  "indexmap",
  "polars-error",
  "polars-utils",
+ "serde",
  "version_check",
 ]
 
@@ -1120,6 +1137,7 @@ dependencies = [
  "polars-ops",
  "polars-utils",
  "regex",
+ "serde",
 ]
 
 [[package]]
@@ -1141,6 +1159,7 @@ dependencies = [
  "polars-error",
  "raw-cpuid",
  "rayon",
+ "serde",
  "stacker",
  "sysinfo",
  "version_check",

--- a/minimal_plugin/Cargo.toml
+++ b/minimal_plugin/Cargo.toml
@@ -12,6 +12,8 @@ pyo3 = { version = "0.22.2", features = ["extension-module", "abi3-py38"] }
 pyo3-polars = { version = "0.17.0", features = ["derive", "dtype-array"] }
 serde = { version = "1", features = ["derive"] }
 polars = { version = "0.43.1", features = ["dtype-array"] }
+polars-plan = { version = "0.43.1", features = ["serde"] }
+serde_json = "1.0.128"
 
 
 # hopefully temporary until

--- a/minimal_plugin/minimal_plugin/__init__.py
+++ b/minimal_plugin/minimal_plugin/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 import polars as pl
 from polars.plugins import register_plugin_function
@@ -9,17 +9,23 @@ from polars.plugins import register_plugin_function
 from minimal_plugin._internal import __version__ as __version__
 
 if TYPE_CHECKING:
-    from minimal_plugin.typing import IntoExpr
+    from minimal_plugin.typing import IntoExpr, PolarsDataType
 
 LIB = Path(__file__).parent
 
 
-def array(expr: IntoExpr, dtype: str) -> pl.Expr:
+def array(expr: IntoExpr, dtype: Optional[PolarsDataType]) -> pl.Expr:
+    if dtype is None:
+        dtype_expr = ""
+    else:
+        # Hacky way to pass a DataType to rust, we serialize an expression
+        # for selecting columns based on dtypes.
+        dtype_expr = pl.col(dtype).meta.serialize(format="json")
     return register_plugin_function(
         args=[expr],
         plugin_path=LIB,
         function_name="array",
         is_elementwise=True,
-        kwargs={"dtype": dtype},
+        kwargs={"dtype_expr": dtype_expr},
         input_wildcard_expansion = True # It seems we need this to get all columns at once?
     )

--- a/minimal_plugin/run.py
+++ b/minimal_plugin/run.py
@@ -38,7 +38,7 @@ def build_array_i32():
 
     # Now we call our plugin:
     # sleep(30)
-    result = print(df.with_columns(arr=mp.array(pl.all(), dtype="f64")))
+    result = print(df.with_columns(arr=mp.array(pl.all(), dtype=pl.Float64)))
     print(result)
 
 # build_array_f64()

--- a/minimal_plugin/src/expressions.rs
+++ b/minimal_plugin/src/expressions.rs
@@ -14,7 +14,7 @@ struct ArrayKwargs {
     dtype: String,
 }
 
-pub fn array_output_type(input_fields: &[Field]) -> PolarsResult<Field> {
+fn array_output_type(input_fields: &[Field], _kwargs: ArrayKwargs) -> PolarsResult<Field> {
     if input_fields.is_empty() {
         // TODO: Allow specifying dtype?
         polars_bail!(ComputeError: "need at least one input field to determine dtype")
@@ -37,10 +37,7 @@ pub fn array_output_type(input_fields: &[Field]) -> PolarsResult<Field> {
     ))
 }
 
-// It looks like output_type_fn_kwargs can support keyword arguments??
-// But I can't find any docs and am not sure how to use it.
-// #[polars_expr(output_type_fn_kwargs=array_output_type)]
-#[polars_expr(output_type_func=array_output_type)]
+#[polars_expr(output_type_func_with_kwargs=array_output_type)]
 fn array(inputs: &[Series], kwargs: ArrayKwargs) -> PolarsResult<Series> {
     array_internal(inputs, kwargs)
 }

--- a/minimal_plugin/src/expressions.rs
+++ b/minimal_plugin/src/expressions.rs
@@ -6,7 +6,7 @@ use pyo3_polars::derive::polars_expr;
 use pyo3_polars::export::polars_core::utils::Container;
 use serde::Deserialize;
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 struct ArrayKwargs {
     // I guess DataType is not one of the serializable types?
     // In the source code I see this done vie Wrap<DataType>
@@ -153,8 +153,8 @@ mod tests {
             let f: Field = (col.field().to_mut()).clone();
             fields.push(f);
         }
-        let kwargs = ArrayKwargs{dtype: "f64".to_string()};
-        let expected_result = array_output_type(&fields).unwrap();
+        let kwargs = ArrayKwargs{dtype_expr: "{\"DtypeColumn\":[\"Float64\"]}".to_string()};
+        let expected_result = array_output_type(&fields, kwargs.clone()).unwrap();
         println!("expected result\n{:?}\n", &expected_result);
 
         let new_arr = array_internal(&cols, kwargs);
@@ -182,8 +182,8 @@ mod tests {
             let f: Field = (col.field().to_mut()).clone();
             fields.push(f);
         }
-        let kwargs = ArrayKwargs{dtype: "f64".to_string()};
-        let expected_result = array_output_type(&fields).unwrap();
+        let kwargs = ArrayKwargs{dtype_expr: "{\"DtypeColumn\":[\"Float64\"]}".to_string()};
+        let expected_result = array_output_type(&fields, kwargs.clone()).unwrap();
         println!("expected result\n{:?}\n", &expected_result);
 
         let new_arr = array_internal(&cols, kwargs);


### PR DESCRIPTION
This is very hacky. It relies on parsing a `DtypeColumn` expression created with something like `pl.col(pl.Float64)`, and the serialized format is not guaranteed to be stable between Polars versions so this might break if using the plugin with a different version of Polars to the one the plugin was compiled with (see https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.meta.serialize.html#polars.Expr.meta.serialize).

This is probably OK as long as this plugin is only for experimentation.

I haven't actually done anything with the dtype besides log it with `dbg!`